### PR TITLE
feature(issue-85)add-user-id-to-calendar-entry

### DIFF
--- a/db.txt
+++ b/db.txt
@@ -57,16 +57,75 @@ create table "public"."events" (
     "habit_id" bigint not null references public.habits(id)
     );    
 
-   create table "public"."calendar_entries" (
-    "id" bigint generated always as identity not null,
-    "title" text not null,
-    "content" text not null,
-    "date" date not null,
-    "start_time" time not null,
-    "end_time" time not null,
-    "created_at" timestamp with time zone default now(),
-    "user_id" uuid not null references auth.users(id)
-    );
+
+CREATE TABLE public.calendar_entries (
+    id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id       uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    title         text NOT NULL,
+    content       text,
+    date          date NOT NULL,
+    start_time    time,
+    end_time      time,
+    all_day       boolean DEFAULT false,
+    created_at    timestamptz DEFAULT now(),
+    updated_at    timestamptz DEFAULT now()
+);
+
+
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+DROP TRIGGER IF EXISTS update_calendar_entries_updated_at ON public.calendar_entries;
+
+CREATE TRIGGER update_calendar_entries_updated_at
+BEFORE UPDATE ON public.calendar_entries
+FOR EACH ROW
+EXECUTE FUNCTION public.update_updated_at_column();
+
+
+ALTER TABLE public.calendar_entries ENABLE ROW LEVEL SECURITY;
+
+
+
+-- SELECT – kasutaja näeb ainult oma sündmusi
+CREATE POLICY "Users can view their own calendar entries"
+ON public.calendar_entries
+FOR SELECT
+USING (user_id = auth.uid());
+
+-- INSERT – kasutaja võib lisada ainult enda kirjeid
+CREATE POLICY "Users can insert their own calendar entries"
+ON public.calendar_entries
+FOR INSERT
+WITH CHECK (user_id = auth.uid());
+
+-- UPDATE – kasutaja võib muuta ainult enda kirjeid
+CREATE POLICY "Users can update their own calendar entries"
+ON public.calendar_entries
+FOR UPDATE
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());
+
+-- DELETE – kasutaja võib kustutada ainult enda kirjeid
+CREATE POLICY "Users can delete their calendar entries"
+ON public.calendar_entries
+FOR DELETE
+USING (user_id = auth.uid());
+
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+ON public.calendar_entries TO authenticated;
+
+
+CREATE INDEX calendar_user_date_idx
+ON public.calendar_entries (user_id, date);
+
 
 
 


### PR DESCRIPTION
Added user-id and also updated the table to update, delete ect.

Closes: #85 